### PR TITLE
bugfix get_current_tag

### DIFF
--- a/bin/check_git
+++ b/bin/check_git
@@ -496,7 +496,7 @@ get_current_branch() {
 get_current_tag() {
 	_path="${1}"
 
-	_tag="$( run "cd ${_path} && git log --pretty=format:'%d' --abbrev-commit --date=short -1 | grep -Eo 'tag:.*?,' | sed 's/,.*$//g' | sed 's/tag:[[:space:]]*//g'" )"
+	_tag="$( run "cd ${_path} && git log --pretty=format:'%d' --abbrev-commit --date=short -1 | grep -Eo 'tag:.*?[,)]' | sed 's/[,)].*$//g' | sed 's/tag:[[:space:]]*//g'" )"
 	if [ "${_tag}" = "" ]; then
 		echo
 		return 1


### PR DESCRIPTION
It fails on
 (HEAD, tag: live-20220830-2)
and succeeds on
 (HEAD, tag: live-20220901-1, origin/live)
small patch to the grep and sed to not require
a comma at the end of the tag name.
